### PR TITLE
Add ability to send verification email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ python:
 cache: pip
 
 env:
-  - DJANGO='>= 1.11, < 1.12'
-  - DJANGO='>= 2.0, < 2.1'
   - DJANGO='>= 2.1, < 2.2'
+  - DJANGO='>= 2.2, < 2.3'
 
 install:
   - pip install --upgrade pip
@@ -33,7 +32,7 @@ jobs:
       if: tag IS present
 
       python: "3.7"
-      env: DJANGO='>= 2.1, < 2.2'
+      env: DJANGO='>= 2.2, < 2.3'
 
       # Skip usual steps
       install: skip

--- a/email_auth/models.py
+++ b/email_auth/models.py
@@ -1,6 +1,7 @@
 import string
 import uuid
 
+import email_utils
 from django.conf import settings
 from django.db import models
 from django.utils import crypto
@@ -204,3 +205,23 @@ class EmailVerification(models.Model):
             is for.
         """
         return f"Verification for {self.email}"
+
+    def send_email(self):
+        """
+        Send an email containing the verification token to the email
+        address being verified.
+        """
+        context = {
+            "email": self.email,
+            "user": self.email.user,
+            "verification": self,
+        }
+        template = "email_auth/emails/verify-email"
+
+        email_utils.send_email(
+            context=context,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[self.email.address],
+            subject=_("Please Verify Your Email Address"),
+            template_name=template,
+        )

--- a/email_auth/templates/email_auth/emails/verify-email.txt
+++ b/email_auth/templates/email_auth/emails/verify-email.txt
@@ -1,0 +1,6 @@
+{% load i18n %}{% blocktrans with email_address=email.address token=verification.token %}Hello {{ user }},
+
+Please verify your email address ({{ email_address }}) using the following token:
+
+{{ token }}
+{% endblocktrans %}

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,8 @@ setup(
         "Development Status :: 3 - Alpha",
         # Supported versions of Django
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
@@ -37,5 +36,5 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     # Dependencies
-    install_requires=["Django >= 1.10"],
+    install_requires=["Django >= 2.1", "django-email-utils >= 1.0"],
 )


### PR DESCRIPTION
Closes #5 

Add the ability to send a verification email containing the unique token used to verify an address by using the `send_email` method of an `EmailVerification` instance.