### PR TITLE
Add duplicate email notification method.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Features
 * #11: Added utility method ``EmailAddress.send_verification_email`` to
   encapsulate the process of creating an ``EmailVerification`` instance and
   sending an email for it.
+* #14: Added method to send a notification that an email address had another
+  registration attempt.
 
 ******
 v0.1.0

--- a/email_auth/models.py
+++ b/email_auth/models.py
@@ -129,6 +129,22 @@ class EmailAddress(models.Model):
         """
         return self.address
 
+    def send_duplicate_notification(self):
+        """
+        Send an email notifying the user that this email address has
+        already been registered.
+        """
+        context = {"email": self}
+        template = "email_auth/emails/duplicate-email"
+
+        email_utils.send_email(
+            context=context,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[self.address],
+            subject=_("Your Email Address has Already Been Registered"),
+            template_name=template,
+        )
+
     def send_verification_email(self):
         """
         Create and send a verification email to the address associated

--- a/email_auth/templates/email_auth/emails/duplicate-email.txt
+++ b/email_auth/templates/email_auth/emails/duplicate-email.txt
@@ -1,0 +1,9 @@
+{% load i18n %}{% blocktrans with user=email.user %}Hello {{ user }},
+
+Someone recently attempted to register this email address which you have already
+registered. If this was not you, you can safely ignore this message.
+
+If you have forgotten your password, please reset your password. If you have not
+verified this email address yet and your verification token is lost or expired,
+please resend the verification email.
+{% endblocktrans %}


### PR DESCRIPTION
Added a method to easily allow for sending a notification to a user that
their email address had another registration attempt.

Closes #14