### PR TITLE
Add notification for verified emails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 #########
 
+**************
+In Development
+**************
+
+Features
+* #20: Add `EmailAddress.send_already_verified` method to send a notification to
+  the user that their email address has already been verified.
+
 ******
 v0.2.0
 ******

--- a/email_auth/models.py
+++ b/email_auth/models.py
@@ -129,6 +129,22 @@ class EmailAddress(models.Model):
         """
         return self.address
 
+    def send_already_verified(self):
+        """
+        Send an email notifying the user that this email address has
+        already been verified.
+        """
+        context = {"email": self}
+        template = "email_auth/emails/already-verified"
+
+        email_utils.send_email(
+            context=context,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[self.address],
+            subject=_("Your Email Address has Already Been Verified"),
+            template_name=template,
+        )
+
     def send_duplicate_notification(self):
         """
         Send an email notifying the user that this email address has

--- a/email_auth/templates/email_auth/emails/already-verified.txt
+++ b/email_auth/templates/email_auth/emails/already-verified.txt
@@ -1,0 +1,5 @@
+{% load i18n %}{% blocktrans with user=email.user %}Hello {{ user }},
+
+You have already verified this email address. If you are having trouble logging
+in, try resetting your password.
+{% endblocktrans %}

--- a/email_auth/test/models/test_email_address_model.py
+++ b/email_auth/test/models/test_email_address_model.py
@@ -52,6 +52,24 @@ def test_repr():
 
 
 @mock.patch("email_auth.models.email_utils.send_email", autospec=True)
+def test_send_already_verified(mock_send_email):
+    """
+    This method should send a notification to the email address letting
+    the user know their email address is already verified.
+    """
+    email = models.EmailAddress(address="test@example.com")
+    email.send_already_verified()
+
+    assert mock_send_email.call_args[1] == {
+        "context": {"email": email},
+        "from_email": settings.DEFAULT_FROM_EMAIL,
+        "recipient_list": [email.address],
+        "subject": "Your Email Address has Already Been Verified",
+        "template_name": "email_auth/emails/already-verified",
+    }
+
+
+@mock.patch("email_auth.models.email_utils.send_email", autospec=True)
 def test_send_duplicate_notification(mock_send_email):
     """
     This method should send a notification to the email address letting


### PR DESCRIPTION
If an email address has already been verified, the `EmailAddress.send_already_verified` method can be used to send the user a notification informing them of this fact.

Closes #20