### PR TITLE
Populate `time_sent` field for email verification.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,18 @@ In Development
 **************
 
 Features
-* #6: Add `PasswordReset` model to facilitate password resets using verified
+========
+
+* #6: Add ``PasswordReset`` model to facilitate password resets using verified
   email addresses.
-* #20: Add `EmailAddress.send_already_verified` method to send a notification to
-  the user that their email address has already been verified.
+* #20: Add ``EmailAddress.send_already_verified`` method to send a notification
+  to the user that their email address has already been verified.
+
+Bug Fixes
+=========
+
+* #22: The ``time_sent`` field is now populated when calling
+  ``EmailVerification.send_email``.
 
 ******
 v0.2.0

--- a/email_auth/models.py
+++ b/email_auth/models.py
@@ -271,6 +271,9 @@ class EmailVerification(models.Model):
             template_name=template,
         )
 
+        self.time_sent = timezone.now()
+        self.save()
+
     def verify(self):
         """
         Mark the associated email address as verified and delete the

--- a/email_auth/test/models/test_email_verification_model.py
+++ b/email_auth/test/models/test_email_verification_model.py
@@ -38,11 +38,13 @@ def test_repr():
     assert repr(verification) == expected
 
 
+@mock.patch("email_auth.models.EmailVerification.save", autospec=True)
 @mock.patch("email_auth.models.email_utils.send_email", autospec=True)
-def test_send_email(mock_send_email):
+@mock.patch("email_auth.models.timezone.now", autospec=True)
+def test_send_email(mock_now, mock_send_email, _):
     """
-    Sending an email should use django-email-utils to send the
-    verification token to the user.
+    This method should send the email verification token to the
+    associated email address and record the send time of the email.
     """
     user = get_user_model()()
     email = models.EmailAddress(address="test@example.com", user=user)
@@ -61,6 +63,9 @@ def test_send_email(mock_send_email):
         "subject": "Please Verify Your Email Address",
         "template_name": "email_auth/emails/verify-email",
     }
+
+    assert verification.time_sent == mock_now.return_value
+    assert verification.save.call_count == 1
 
 
 def test_str():

--- a/email_auth/test/models/test_password_reset_model.py
+++ b/email_auth/test/models/test_password_reset_model.py
@@ -43,7 +43,7 @@ def test_repr():
 @mock.patch("email_auth.models.PasswordReset.save", autospec=True)
 @mock.patch("email_auth.models.email_utils.send_email", autospec=True)
 @mock.patch("email_auth.models.timezone.now", autospec=True)
-def test_send_duplicate_notification(mock_now, mock_send_email, mock_save):
+def test_send_email(mock_now, mock_send_email, mock_save):
     """
     This method should send the password reset token to the associated
     email address and record the send time of the email.


### PR DESCRIPTION
When calling `EmailVerification.send_email`, the `time_sent` field is now properly populated.

Fixes #22