### PR TITLE
Fix default ordering of `EmailVerification` model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Changelog
 In Development
 **************
 
+Breaking Changes
+================
+
+* #23: The default ordering of `EmailVerification` instances has been switched
+  from ``email__normalized_address`` (doesn't exist) to ``time_created``.
+
 Features
 ========
 

--- a/email_auth/migrations/0002_emailverification.py
+++ b/email_auth/migrations/0002_emailverification.py
@@ -64,7 +64,7 @@ class Migration(migrations.Migration):
             options={
                 "verbose_name": "email verification",
                 "verbose_name_plural": "email verifications",
-                "ordering": ("email__normalized_address",),
+                "ordering": ("time_created",),
             },
         )
     ]

--- a/email_auth/models.py
+++ b/email_auth/models.py
@@ -228,7 +228,7 @@ class EmailVerification(models.Model):
     )
 
     class Meta:
-        ordering = ("email__normalized_address",)
+        ordering = ("time_created",)
         verbose_name = _("email verification")
         verbose_name_plural = _("email verifications")
 


### PR DESCRIPTION
The default ordering of `EmailVerification` models has been switched from the non-existent field `email__normalized_address` to `time_created`.

Fixes #23