### PR TITLE
Allow for using links over raw tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 #########
 
+**************
+In Development
+**************
+
+Features
+========
+
+* :issue:`32`: Link to frontend pages for resetting passwords and verifying
+  email addresses. These links are specified with the ``PASSWORD_RESET_URL`` and
+  ``EMAIL_VERIFICATION_URL`` settings, respectively.
+
 ******
 v0.3.1
 ******

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@
    :caption: Contents:
 
    installation
+   settings
    templates
    changelog-proxy
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,13 @@ Add ``email_auth`` to your ``INSTALLED_APPS``:
         # Django apps
 
         # Third party apps
+
+        # Core models and templates:
         "email_auth",
+
+        # If you would like to use the provided REST API:
+        "email_auth.interfaces.rest",
+
         # More third party apps
 
         # Your custom apps
@@ -46,6 +52,8 @@ Next ensure Django is `set up to send emails <django-emails>`_. Additionally,
 ensure ``DEFAULT_FROM_EMAIL`` is set. This is the address that all account
 related emails such as email verifications and password reset emails are sent
 from.
+
+See :ref:`app-settings` for configuration options.
 
 .. _django-emails: https://docs.djangoproject.com/en/dev/topics/email/
 .. _django-simple-email-auth-pypi: https://pypi.org/project/django-simple-email-auth/

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,45 @@
+.. _app-settings:
+
+########
+Settings
+########
+
+Settings are provided as a dictionary named ``EMAIL_AUTH`` in the Django
+settings file. For example::
+
+    # settings.py
+
+    EMAIL_AUTH = {
+        "EMAIL_VERIFICATION_URL": "https://example.com/{key}"
+    }
+
+.. _email-verification-url:
+
+**************************
+``EMAIL_VERIFICATION_URL``
+**************************
+
+Default
+  ``None``
+
+Example
+  ``https://my-frontend.com/verify-email/{key}``
+
+A template used to construct the URL of the page that users visit to verify
+their email. The placeholder ``{key}`` will be replaced with the verification
+token.
+
+.. _password-reset-url:
+
+**********************
+``PASSWORD_RESET_URL``
+**********************
+
+Default
+  ``None``
+
+Example
+  ``https://my-frontend.com/reset-password/{key}``
+
+A template used to construct the URL of the page that users visit to reset their
+password. The placeholder ``{key}`` will be replaced with the reset token.

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -71,6 +71,10 @@ Provided Context
   ``verification``
     The ``EmailVerification`` instance containing the token used to verify
     ownership of the email address.
+  ``verification_url``
+    If the :ref:`email-verification-url` setting has been set, this variable
+    contains the provided URL formatted with the verification token. If the
+    setting was not provided, this is ``None``.
 
 **************
 Password Reset
@@ -86,6 +90,10 @@ Provided Context
   ``password_reset``
     The ``PasswordReset`` instance containing the token used to reset the user's
     password.
+  ``reset_url``
+    If the :ref:`password-reset-url` setting has been set, this variable
+    contains the provided template formatted with the reset token. If the
+    setting was not provided, this is ``None``.
 
 
 .. _django-email-utils: https://github.com/cdriehuys/django-email-utils

--- a/email_auth/app_settings.py
+++ b/email_auth/app_settings.py
@@ -1,0 +1,56 @@
+"""
+Settings specific to ``simple_email_auth``.
+
+The setting implementation is modeled on "Django Allauth's" from:
+https://github.com/pennersr/django-allauth/blob/master/allauth/account/app_settings.py
+"""
+
+import sys
+from typing import Optional
+
+
+class AppSettings(object):
+    def _setting(self, name: str, default: any):
+        """
+        Retrieve a setting from the current Django settings.
+
+        Settings are retrieved from the ``EMAIL_AUTH`` dict in the
+        settings file.
+
+        Args:
+            name:
+                The name of the setting to retrieve.
+            default:
+                The setting's default value.
+
+        Returns:
+            The value provided in the settings dictionary if it exists.
+            The default value is returned otherwise.
+        """
+        from django.conf import settings
+
+        settings_dict = getattr(settings, "EMAIL_AUTH", {})
+
+        return settings_dict.get(name, default)
+
+    @property
+    def EMAIL_VERIFICATION_URL(self) -> Optional[str]:
+        """
+        The template to use for the email verification url.
+        """
+        return self._setting("EMAIL_VERIFICATION_URL", None)
+
+    @property
+    def PASSWORD_RESET_URL(self) -> Optional[str]:
+        """
+        The template to use for the password reset url.
+        """
+        return self._setting("PASSWORD_RESET_URL", None)
+
+
+# Ugly? Guido recommends this himself ...
+# http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
+
+app_settings = AppSettings()
+app_settings.__name__ = __name__
+sys.modules[__name__] = app_settings

--- a/email_auth/interfaces/rest/__init__.py
+++ b/email_auth/interfaces/rest/__init__.py
@@ -1,0 +1,3 @@
+default_app_config = (
+    "email_auth.interfaces.rest.apps.EmailAuthRESTInterfaceConfig"
+)

--- a/email_auth/interfaces/rest/apps.py
+++ b/email_auth/interfaces/rest/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class EmailAuthRESTInterfaceConfig(AppConfig):
+    """
+    Default configuration for ``email_auth.interfaces.rest``.
+    """
+
+    name = "email_auth.interfaces.rest"
+    verbose_name = _("Simple Email Authentication REST Interface")

--- a/email_auth/interfaces/rest/templates/email_auth/emails/reset-password.txt
+++ b/email_auth/interfaces/rest/templates/email_auth/emails/reset-password.txt
@@ -1,0 +1,6 @@
+{% load i18n %}{% blocktrans with user=password_reset.email.user %}Hello {{ user }},
+
+Please reset your password using the following link:
+
+{{ reset_url }}
+{% endblocktrans %}

--- a/email_auth/interfaces/rest/templates/email_auth/emails/verify-email.txt
+++ b/email_auth/interfaces/rest/templates/email_auth/emails/verify-email.txt
@@ -1,0 +1,6 @@
+{% load i18n %}{% blocktrans %}Hello {{ user }},
+
+Please visit the following URL to verify your email address:
+
+{{ verification_url }}
+{% endblocktrans %}

--- a/email_auth/test/test_app_settings.py
+++ b/email_auth/test/test_app_settings.py
@@ -1,0 +1,52 @@
+from email_auth import app_settings
+
+
+def verify_setting_behavior(settings, setting_name, test_value, default=None):
+    """
+    Verify the behavior of a setting for the scenarios when it is
+    provided, is not provided, and when the entire settings dictionary
+    is not provided.
+
+    Args:
+        settings:
+            The settings dictionary to manipulate for the test.
+        setting_name:
+            The name of the setting to test.
+        test_value:
+            The value to use when the setting is provided.
+        default:
+            The expected default value.
+    """
+    # No settings provided
+    if hasattr(settings, "EMAIL_AUTH"):
+        del settings.EMAIL_AUTH
+
+    assert getattr(app_settings, setting_name) == default
+
+    # Setting omitted
+    settings.EMAIL_AUTH = {}
+
+    assert getattr(app_settings, setting_name) == default
+
+    # Setting provided
+    settings.EMAIL_AUTH = {setting_name: test_value}
+
+    assert getattr(app_settings, setting_name) == test_value
+
+
+def test_email_verification_url(settings):
+    """
+    Test the behavior of the ``EMAIL_VERIFICATION_URL`` setting.
+    """
+    verify_setting_behavior(
+        settings, "EMAIL_VERIFICATION_URL", "example.com/{key}"
+    )
+
+
+def test_password_reset_url(settings):
+    """
+    Test the behavior of the ``PASSWORD_RESET_URL`` setting.
+    """
+    verify_setting_behavior(
+        settings, "PASSWORD_RESET_URL", "example.com/{key}"
+    )


### PR DESCRIPTION
Instead of providing the raw tokens for email verifications and password
resets, users can now configure the app to send links to other web
pages.

Closes #32